### PR TITLE
support embeddings via ollama

### DIFF
--- a/src/openparse/processing/__init__.py
+++ b/src/openparse/processing/__init__.py
@@ -2,6 +2,7 @@ from .ingest import (
     IngestionPipeline,
     BasicIngestionPipeline,
     SemanticIngestionPipeline,
+    LocalSemanticIngestionPipeline,
     NoOpIngestionPipeline,
 )
 from .basic_transforms import (
@@ -15,7 +16,7 @@ from .basic_transforms import (
     CombineNodesSpatially,
     RemoveNodesBelowNTokens,
 )
-from .semantic_transforms import CombineNodesSemantically, OpenAIEmbeddings
+from .semantic_transforms import CombineNodesSemantically, OpenAIEmbeddings, OllamaEmbeddings
 
 __all__ = [
     "ProcessingStep",
@@ -29,8 +30,10 @@ __all__ = [
     "BasicIngestionPipeline",
     "IngestionPipeline",
     "SemanticIngestionPipeline",
+    "LocalSemanticIngestionPipeline",
     "NoOpIngestionPipeline",
     "RemoveNodesBelowNTokens",
     "CombineNodesSemantically",
     "OpenAIEmbeddings",
+    "OllamaEmbeddings",
 ]


### PR DESCRIPTION
Note: This maybe made obsolete by #8.

This add semantic_transforms.OllamaEmbeddings, which allows to calculate embeddings locally using ollama (https://ollama.com/), following the api from OpenAIEmbeddings. Currently, ollama does not support batching (but it is on their roadmap, cf. https://ollama.com/blog/embedding-models).

The LocalSemanticIngestionPipeline shows how it can be used.

To test locally, install ollama, then pull an embeddings model, such as https://ollama.com/library/mxbai-embed-large, then:

```python
from openparse import processing, DocumentParser
semantic_pipeline = processing.LocalSemanticIngestionPipeline(
    url="http://localhost:11434",
    model="mxbai-embed-large",
)
parser = DocumentParser(
        processing_pipeline=semantic_pipeline,
)
parsed = parser.parse("path/to/file.pdf")
```