### PR TITLE
fix: Fix sequence item 2: expected str instance, NoneType found exception when table output is set to markdown.

### DIFF
--- a/src/openparse/tables/parse.py
+++ b/src/openparse/tables/parse.py
@@ -51,6 +51,11 @@ def _ingest_with_pymupdf(
         tabs = page.find_tables()
         for i, tab in enumerate(tabs.tables):
             headers = tab.header.names
+            for j, header in enumerate(headers):
+                if header is None:
+                    headers[j] = ""
+                else:
+                    headers[j] = header.strip()
             lines = tab.extract()
 
             if parsing_args.table_output_format == "str":

--- a/src/openparse/tables/pymupdf/parse.py
+++ b/src/openparse/tables/pymupdf/parse.py
@@ -26,7 +26,7 @@ def output_to_markdown(headers: List[str], rows: List[List[str]]) -> str:
     markdown_output += "|---" * len(headers) + "|\n"
 
     for row in rows:
-        processed_row = [" " if cell in [None, ""] else cell for cell in row]
+        processed_row = [" " if cell in [None, ""] else cell.replace("\n", "") for cell in row]
         markdown_output += "| " + " | ".join(processed_row) + " |\n"
 
     return markdown_output

--- a/src/openparse/tables/pymupdf/parse.py
+++ b/src/openparse/tables/pymupdf/parse.py
@@ -26,7 +26,7 @@ def output_to_markdown(headers: List[str], rows: List[List[str]]) -> str:
     markdown_output += "|---" * len(headers) + "|\n"
 
     for row in rows:
-        processed_row = [" " if cell in [None, ""] else cell.replace("\n", "") for cell in row]
+        processed_row = [" " if cell in [None, ""] else cell.replace("\n", " ") for cell in row]
         markdown_output += "| " + " | ".join(processed_row) + " |\n"
 
     return markdown_output


### PR DESCRIPTION
# behavior:

I get an exception as follows:

```
/python3.10/site-packages/openparse/tables/pymupdf/parse.py", line 25, in output_to_markdown
 markdown_output = "| " + " | ".join(headers) + " |\n"
TypeError: sequence item 2: expected str instance, NoneType found
```

 When parsing PDF tables, the output format is set to

```
table_args={
 "parsing_algorithm": "pymupdf",
 "table_output_format": "markdown"
 }
```

After analysis, I found that the reason may be the following:
When the headers of the table are:

```
header = ['(See Note 11)', '', None, None]
```
Then execute the following code
```
 markdown_output = "| " + " | ".join(headers) + " |\n"
 markdown_output += "|---" * len(headers) + "|\n"
```
You will get the following error
```
/python3.10/site-packages/openparse/tables/pymupdf/parse.py", line 25, in output_to_markdown
 markdown_output = "| " + " | ".join(headers) + " |\n"
TypeError: sequence item 2: expected str instance, NoneType found
```
So my solution is to replace None with ' ' to solve this problem