### PR TITLE
Update doc on export of bboxes visualization

### DIFF
--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -38,6 +38,6 @@ You can also export the results marked up over the original pdf to a seperate pd
 pdf = openparse.Pdf(basic_doc_path)
 pdf.export_with_bboxes(
     parsed_basic_doc.nodes,
-    output_path="./sample-docs/mobile-home-manual-marked-up.pdf"
+    output_pdf="./sample-docs/mobile-home-manual-marked-up.pdf"
 )
 ```


### PR DESCRIPTION
Argument `output_path` is invalid. Change to `output_pdf` which is now the expected value