### PR TITLE
get_mime_type bugfix

### DIFF
--- a/src/openparse/text/pdfminer/core.py
+++ b/src/openparse/text/pdfminer/core.py
@@ -10,6 +10,7 @@ from pdfminer.layout import (
     LTTextContainer,
     LTTextLine,
 )
+from pdfminer.psparser import PSLiteral
 from pydantic import BaseModel, model_validator
 
 from openparse.pdf import Pdf
@@ -64,8 +65,8 @@ def _extract_chars(text_line: LTTextLine) -> List[CharElement]:
 
 
 def get_mime_type(pdf_object: LTImage) -> Optional[str]:
-    subtype = pdf_object.stream.attrs.get("Subtype", {"name": None}).name
-    filter_ = pdf_object.stream.attrs.get("Filter", {"name": None}).name
+    subtype = pdf_object.stream.attrs.get("Subtype", PSLiteral(None)).name
+    filter_ = pdf_object.stream.attrs.get("Filter", PSLiteral(None)).name
     if subtype == "Image":
         if filter_ == "DCTDecode":
             return "image/jpeg"


### PR DESCRIPTION
pdf_object.attrs.get() return PSLiteral object not a dict. 
Because they returned dict, It raised Exception when they call .name 
So I fixed it.